### PR TITLE
UI: show school name with email on new line in doctor appointments

### DIFF
--- a/resources/views/doctor-appointments.blade.php
+++ b/resources/views/doctor-appointments.blade.php
@@ -55,7 +55,14 @@
                                 -
                             @endif
                         </td>
-                        <td class="appt-facility">{{ $appointment->healthFacility->name ?? 'N/A' }}</td>
+                        <td class="appt-facility">
+                            @if($appointment->healthFacility)
+                                {{ $appointment->healthFacility->name }}<br>
+                                <small class="text-muted">{{ $appointment->healthFacility->email ?? '-' }}</small>
+                            @else
+                                N/A
+                            @endif
+                        </td>
                         <td>{{ $appointment->duration }} mins</td>
                         <td class="appt-status">
                             <span class="badge bg-{{ $appointment->status == 'confirmed' ? 'success' : ($appointment->status == 'cancelled' ? 'danger' : ($appointment->status=='completed' ? 'secondary' : 'warning')) }}">{{ ucfirst($appointment->status) }}</span>

--- a/resources/views/doctor-appointments.blade.php
+++ b/resources/views/doctor-appointments.blade.php
@@ -47,7 +47,14 @@
                     <tr data-id="{{ $appointment->id }}">
                         <td class="appt-time">{{ $appointment->appointment_time->format('M d, Y h:i A') }}</td>
                         <td class="appt-patient">{{ $appointment->student->name ?? $appointment->patient->name ?? '-' }}</td>
-                        <td class="appt-school">{{ $appointment->school->name ?? '-' }}</td>
+                        <td class="appt-school">
+                            @if($appointment->school)
+                                {{ $appointment->school->name }}<br>
+                                <small class="text-muted">{{ $appointment->school->email ?? '-' }}</small>
+                            @else
+                                -
+                            @endif
+                        </td>
                         <td class="appt-facility">{{ $appointment->healthFacility->name ?? 'N/A' }}</td>
                         <td>{{ $appointment->duration }} mins</td>
                         <td class="appt-status">


### PR DESCRIPTION
Minor UI improvement: show the associated school’s email on a new line beneath the school name in the Doctor Appointments table so doctors can quickly see the institution contact without navigating elsewhere.

