### PR TITLE
style(email): remove logo and center 'keti ai' heading in OTP template

### DIFF
--- a/resources/views/emails/otp.blade.php
+++ b/resources/views/emails/otp.blade.php
@@ -12,27 +12,17 @@
                 'doctor' => 'Doctor',
                 default => 'School'
             };
+                
         @endphp
 
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f5f7fb; padding:24px 0;">
             <tr>
                 <td align="center">
-                    <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width:600px; width:100%; background:#ffffff; border-radius:12px; box-shadow:0 4px 16px rgba(2,6,23,0.06); overflow:hidden;">
+                
                         <tr>
-                                                            <td style="padding:16px 24px; background:#FF00F8; color:#ffffff;">
-                                                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                                                                    <tr>
-                                                                        <td style="vertical-align:middle;">
-                                                                            <a href="https://ketiai.com" target="_blank" style="text-decoration:none; color:#ffffff; display:inline-flex; align-items:center; gap:10px;">
-                                                                                                                                @php
-                                                                                                                                    $logoSrc = config('app.url') . '/images/emoji-logo-white.svg';
-                                                                                                                                @endphp
-                                                                                                                                <img src="{{ $logoSrc }}" alt="{{ config('app.name') }}" width="36" height="36" style="display:block; border:0;">
-                                                                            </a>
-                                                                            <div style="opacity:0.9; font-size:13px; margin-top:4px;">Secure Sign-In</div>
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
+                                                            <td style="padding:16px 24px; background:#FF00F8; color:#ffffff; text-align:center;">
+                                                                <div style="font-size:18px; font-weight:700; letter-spacing:0.3px;">KETI AI</div>
+                                                                <div style="opacity:0.9; font-size:13px; margin-top:4px;">Secure Sign-In</div>
                                                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
This pull request updates the design of the OTP email template to simplify the header and improve visual clarity. The most important change is replacing the previous logo and link with a straightforward, centered text header.

**Email template design improvements:**

* Replaced the logo and external link in the header with a centered text header displaying "KETI AI" and a subtitle "Secure Sign-In" for a cleaner and more direct presentation.